### PR TITLE
[FEATURE] Desktop & Mobile Header

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,11 +1,55 @@
 import Image from "next/image";
 import styles from "./page.module.css";
 import LandingPage from "@/components/LandingPage";
+import Header from "@/components/Header";
 export default function Home() {
   return (
     <>
+      <Header />
       <LandingPage />
-      <div>Welcome </div>
+      <div>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. In pretium purus eu lorem cursus,
+        vitae convallis augue tincidunt. Donec consequat aliquet fringilla. Quisque fermentum sed
+        orci non placerat. Nulla pretium placerat tortor quis tempor. Nam id leo eget nulla
+        ultricies interdum. Pellentesque dignissim, diam quis sagittis posuere, eros orci porta
+        turpis, vitae viverra orci erat vitae metus. Morbi quis tempor massa, a feugiat neque.
+        Praesent volutpat ligula a felis tristique finibus. Sed faucibus purus eget nunc
+        ullamcorper, vitae ultricies orci congue. Nulla facilisi. Ut nec dignissim augue. Morbi
+        sodales tempus nibh ac pharetra. Curabitur quam felis, tincidunt vel sem id, feugiat
+        consectetur est. Donec urna nunc, cursus vitae fermentum ut, laoreet id metus. Mauris
+        eleifend nisi odio, vel varius lorem porttitor sit amet. Proin sit amet lorem nec diam
+        eleifend placerat. Phasellus est risus, dictum sit amet dui eget, tincidunt bibendum quam.
+        Mauris porta, tortor quis mollis dapibus, ante arcu sollicitudin ex, pulvinar rutrum ex ante
+        vitae purus. Nullam consequat urna ac elementum tempor. Nam quis finibus purus. Donec non
+        lacinia ligula, sit amet semper sapien. Morbi mattis ac justo lobortis aliquet. Quisque at
+        enim dolor. Etiam vulputate, elit sit amet aliquam mattis, diam elit volutpat elit, id
+        congue nunc libero non odio. Cras pretium, libero id fringilla aliquet, leo risus venenatis
+        ligula, sit amet dignissim turpis nulla sed libero. Duis placerat, libero nec bibendum
+        scelerisque, tortor ex suscipit nulla, sit amet pharetra velit dolor a risus. Ut finibus
+        sapien enim, ut tempus augue molestie at. In hac habitasse platea dictumst. Fusce in aliquet
+        sapien. Cras nunc arcu, molestie nec odio et, eleifend sagittis nibh. In ex ligula,
+        imperdiet a nibh vitae, iaculis ullamcorper diam. Aliquam tempor scelerisque diam, ac
+        placerat arcu scelerisque vel. Aenean dictum at arcu non eleifend. Vestibulum consectetur
+        venenatis quam ac vestibulum. Vestibulum eget semper ipsum. Nullam ac nisi commodo, commodo
+        neque nec, gravida arcu. Duis tortor lacus, hendrerit vel finibus ac, porta id ligula.
+        Praesent sed consequat dui. Cras sit amet pellentesque nisl. Duis congue elit sit amet nulla
+        iaculis laoreet. Aenean turpis odio, molestie vel ultrices faucibus, pellentesque ac dolor.
+        Aenean eleifend ex a felis porta, vitae faucibus massa molestie. Vestibulum ut nunc
+        scelerisque, mollis lorem id, porta elit. Praesent in lorem vulputate, vulputate nisl ut,
+        feugiat dui. Nam non felis in elit scelerisque interdum. Aenean massa ipsum, euismod sit
+        amet congue eget, blandit nec nisl. Sed ut ligula nisl. Vestibulum volutpat in est vitae
+        placerat. Nam pharetra ut ipsum nec fermentum. Integer auctor sed felis semper viverra.
+        Fusce convallis lectus non ex iaculis euismod. Morbi ac accumsan ligula. Nulla sit amet
+        fringilla purus. Fusce vel metus pulvinar elit convallis efficitur. Quisque faucibus arcu
+        vitae orci pulvinar, vel congue metus fringilla. Praesent neque neque, placerat id maximus
+        at, consectetur at quam. Duis eget consequat neque. Ut suscipit magna eu metus porta luctus
+        ac vel mi. Sed consectetur ac ipsum in lobortis. Vestibulum hendrerit odio enim, in
+        fringilla felis mollis efficitur. Pellentesque congue felis sed enim pulvinar cursus. Sed ac
+        ligula eget diam lacinia dapibus. Nulla feugiat egestas ex, vel sollicitudin mauris semper
+        vitae. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis
+        egestas. Fusce et quam sit amet orci tempus eleifend vel tempor urna. In interdum sem semper
+        sagittis sagittis. Sed et ex nec mauris eleifend rutrum sed non nibh.{" "}
+      </div>
     </>
   );
 }

--- a/components/CustomButton.jsx
+++ b/components/CustomButton.jsx
@@ -1,0 +1,24 @@
+import { Button } from "@mui/material";
+
+export default function CustomButton({ name, width, marginR }) {
+  return (
+    <Button
+      variant="outlined"
+      sx={{
+        mr: marginR,
+        width: width,
+        textTransform: "none",
+        fontSize: "13px",
+        fontFamily: "SF Mono,Fira Code,Fira Mono,Roboto Mono,monospace",
+        color: "white",
+        borderColor: "#64ffda",
+        "&:hover": {
+          backgroundColor: "#64ffda",
+          color: "black",
+        },
+      }}
+    >
+      {name}
+    </Button>
+  );
+}

--- a/components/CustomButton.jsx
+++ b/components/CustomButton.jsx
@@ -1,14 +1,15 @@
 import { Button } from "@mui/material";
 
-export default function CustomButton({ name, width, marginR }) {
+export default function CustomButton({ name, width, marginR, fontSize, marginT }) {
   return (
     <Button
       variant="outlined"
       sx={{
+        mt: marginT,
         mr: marginR,
         width: width,
         textTransform: "none",
-        fontSize: "13px",
+        fontSize: fontSize,
         fontFamily: "SF Mono,Fira Code,Fira Mono,Roboto Mono,monospace",
         color: "white",
         borderColor: "#64ffda",

--- a/components/DrawerMenu.jsx
+++ b/components/DrawerMenu.jsx
@@ -1,0 +1,96 @@
+import { Drawer, List, ListItem, ListItemText, Divider, IconButton } from "@mui/material";
+import { useState } from "react";
+import CloseIcon from "@mui/icons-material/Close";
+import CustomButton from "./CustomButton";
+
+export default function DrawerMenu({ headerItems, headerButtons, setDrawerOpen, drawerOpen }) {
+  const toggleDrawer = () => {
+    setDrawerOpen((prev) => !prev); // Toggle the drawer state when the close button or an item is clicked
+  };
+
+  return (
+    <Drawer
+      anchor="right"
+      open={drawerOpen}
+      onClose={toggleDrawer}
+      sx={{
+        "& .MuiDrawer-paper": {
+          color: "white",
+          backgroundColor: "var(--background)",
+        },
+      }}
+    >
+      <div style={{ padding: "20px", display: "flex", position: "relative" }}>
+        {/* Close Drawer Button */}
+        <IconButton onClick={toggleDrawer} sx={{ position: "absolute", top: 10, right: 10 }}>
+          <CloseIcon sx={{ color: "white" }} />
+        </IconButton>
+
+        <List
+          sx={{
+            width: 250,
+            paddingTop: "40px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            mt: "30px",
+            height: "100vh",
+          }}
+        >
+          {/* Header Items Section */}
+          <div style={{ marginBottom: "20px", width: "100%" }}>
+            {headerItems.map((item, index) => (
+              <ListItem
+                button
+                key={item}
+                onClick={toggleDrawer}
+                sx={{
+                  display: "flex",
+                  padding: "10px 0",
+                  width: "100%",
+                  "&:hover": {
+                    backgroundColor: "#64ffda",
+                    color: "white",
+                  },
+                }}
+              >
+                <ListItemText
+                  primaryTypographyProps={{
+                    textAlign: "center",
+                  }}
+                >
+                  {item}
+                </ListItemText>
+              </ListItem>
+            ))}
+          </div>
+
+          <Divider sx={{ margin: "10px 0" }} />
+
+          {/* Header Buttons Section */}
+          <div
+            style={{
+              width: "100%",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+            }}
+          >
+            {headerButtons.map((item) => (
+              <div key={item} style={{ width: "100%", display: "flex", justifyContent: "center" }}>
+                <CustomButton
+                  name={item}
+                  width="70%"
+                  marginT="20px"
+                  marginR="0"
+                  fontSize="13px"
+                  onClick={toggleDrawer}
+                />
+              </div>
+            ))}
+          </div>
+        </List>
+      </div>
+    </Drawer>
+  );
+}

--- a/components/DrawerMenu.jsx
+++ b/components/DrawerMenu.jsx
@@ -41,7 +41,6 @@ export default function DrawerMenu({ headerItems, headerButtons, setDrawerOpen, 
           <div style={{ marginBottom: "20px", width: "100%" }}>
             {headerItems.map((item, index) => (
               <ListItem
-                button
                 key={item}
                 onClick={toggleDrawer}
                 sx={{

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -1,11 +1,13 @@
 "use client";
-import { AppBar } from "@mui/material";
+import { AppBar, Link, Button } from "@mui/material";
 import { useState, useEffect, useRef } from "react";
 
 export default function Header() {
   const [isVisible, setIsVisible] = useState(true); // For header visibility
   const [shadow, setShadow] = useState(false); // For header shadow state for not causing re-renders over and over again
   const lastScroll = useRef(0); // For tracking last scroll position
+  const headerItems = ["About Me", "Experience", "Skills", "Contact"];
+  const headerButtons = ["Resume", "Vurdering", "Soft Skills"];
 
   useEffect(() => {
     const handleScroll = () => {
@@ -34,6 +36,8 @@ export default function Header() {
   return (
     <AppBar
       sx={{
+        flexDirection: "row",
+        justifyContent: "flex-end",
         backgroundColor: shadow ? "rgba(var(--background), 0.5)" : "var(--background)",
         backdropFilter: shadow ? "blur(5px)" : "none",
         padding: "25px",
@@ -46,7 +50,51 @@ export default function Header() {
         boxShadow: shadow ? "0 10px 30px -10px #020c1bb3" : "none", // Apply shadow based on scroll position
       }}
     >
-      asd
+      {headerItems.map((item, index) => (
+        <Link
+          href="#"
+          key={item}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            textDecoration: "none",
+            mr: "30px",
+            color: "white",
+            fontFamily: "SF Mono,Fira Code,Fira Mono,Roboto Mono,monospace",
+            fontSize: "13px",
+          }}
+        >
+          <span
+            style={{
+              color: "#64ffda",
+            }}
+          >
+            {`0${index + 1}.`}
+          </span>
+          {item}
+        </Link>
+      ))}
+      {headerButtons.map((item, index) => (
+        <Button
+          href="#"
+          key={item}
+          variant="outlined"
+          sx={{
+            mr: "15px",
+            textTransform: "none",
+            fontSize: "13px",
+            fontFamily: "SF Mono,Fira Code,Fira Mono,Roboto Mono,monospace",
+            color: "white",
+            borderColor: "#64ffda",
+            "&:hover": {
+              backgroundColor: "#64ffda",
+              color: "black",
+            },
+          }}
+        >
+          {item}
+        </Button>
+      ))}
     </AppBar>
   );
 }

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -1,7 +1,9 @@
 "use client";
-import { AppBar, Link } from "@mui/material";
+import { AppBar, Link, useTheme, useMediaQuery, IconButton } from "@mui/material";
 import { useState, useEffect, useRef } from "react";
 import CustomButton from "./CustomButton";
+import DrawerMenu from "./DrawerMenu";
+import MenuIcon from "@mui/icons-material/Menu";
 
 export default function Header() {
   const [isVisible, setIsVisible] = useState(true); // For header visibility
@@ -9,6 +11,15 @@ export default function Header() {
   const lastScroll = useRef(0); // For tracking last scroll position
   const headerItems = ["About Me", "Experience", "Skills", "Contact"];
   const headerButtons = ["Resume", "Vurdering", "Soft Skills"];
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  const [drawerOpen, setDrawerOpen] = useState(false); // State for controlling drawer open/close
+
+  const toggleDrawer = () => {
+    setDrawerOpen((prev) => !prev); // Toggle drawer state
+  };
 
   useEffect(() => {
     const handleScroll = () => {
@@ -34,7 +45,7 @@ export default function Header() {
     };
   }, []);
 
-  return (
+  return !isMobile ? (
     <AppBar
       sx={{
         flexDirection: "row",
@@ -43,7 +54,7 @@ export default function Header() {
         backdropFilter: shadow ? "blur(5px)" : "none",
         padding: "25px",
         position: "fixed",
-        top: isVisible ? "0" : "-80px", // Hide the header when scrolling down
+        top: isVisible ? "0" : "-100px", // Hide the header when scrolling down
         left: 0,
         right: 0,
         transition:
@@ -51,6 +62,7 @@ export default function Header() {
         boxShadow: shadow ? "0 10px 30px -10px #020c1bb3" : "none", // Apply shadow based on scroll position
       }}
     >
+      {/* Header Items*/}
       {headerItems.map((item, index) => (
         <Link
           href="#"
@@ -75,9 +87,39 @@ export default function Header() {
           {item}
         </Link>
       ))}
+
+      {/* Header Buttons */}
       {headerButtons.map((item, index) => (
-        <CustomButton name={item} marginR={"15px"} key={item} />
+        <CustomButton
+          name={item}
+          marginR={"15px"}
+          key={item}
+          fontSize={{ lg: "13px", md: "13px", sm: "9px", xs: "13px" }}
+        />
       ))}
     </AppBar>
+  ) : (
+    <>
+      {/* Mobile View Hamburger Menu Icon */}
+      <IconButton
+        sx={{
+          position: "absolute",
+          top: 20,
+          right: 20,
+          color: "white",
+        }}
+        onClick={toggleDrawer}
+      >
+        <MenuIcon />
+      </IconButton>
+
+      {/* Drawer Menu */}
+      <DrawerMenu
+        headerButtons={headerButtons}
+        headerItems={headerItems}
+        setDrawerOpen={setDrawerOpen}
+        drawerOpen={drawerOpen}
+      />
+    </>
   );
 }

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -1,0 +1,52 @@
+"use client";
+import { AppBar } from "@mui/material";
+import { useState, useEffect, useRef } from "react";
+
+export default function Header() {
+  const [isVisible, setIsVisible] = useState(true); // For header visibility
+  const [shadow, setShadow] = useState(false); // For header shadow state for not causing re-renders over and over again
+  const lastScroll = useRef(0); // For tracking last scroll position
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScroll = window.scrollY;
+      if (currentScroll > 0) {
+        setShadow(true);
+      } else {
+        setShadow(false);
+      }
+
+      if (currentScroll > lastScroll.current) {
+        setIsVisible(false);
+      } else {
+        setIsVisible(true);
+      }
+      lastScroll.current = currentScroll;
+    };
+
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  return (
+    <AppBar
+      sx={{
+        backgroundColor: shadow ? "rgba(var(--background), 0.5)" : "var(--background)",
+        backdropFilter: shadow ? "blur(5px)" : "none",
+        padding: "25px",
+        position: "fixed",
+        top: isVisible ? "0" : "-80px", // Hide the header when scrolling down
+        left: 0,
+        right: 0,
+        transition:
+          "top 0.3s ease, background-color 0.3s ease, backdrop-filter 0.3s ease, box-shadow 0.3s ease",
+        boxShadow: shadow ? "0 10px 30px -10px #020c1bb3" : "none", // Apply shadow based on scroll position
+      }}
+    >
+      asd
+    </AppBar>
+  );
+}

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -1,6 +1,7 @@
 "use client";
-import { AppBar, Link, Button } from "@mui/material";
+import { AppBar, Link } from "@mui/material";
 import { useState, useEffect, useRef } from "react";
+import CustomButton from "./CustomButton";
 
 export default function Header() {
   const [isVisible, setIsVisible] = useState(true); // For header visibility
@@ -75,25 +76,7 @@ export default function Header() {
         </Link>
       ))}
       {headerButtons.map((item, index) => (
-        <Button
-          href="#"
-          key={item}
-          variant="outlined"
-          sx={{
-            mr: "15px",
-            textTransform: "none",
-            fontSize: "13px",
-            fontFamily: "SF Mono,Fira Code,Fira Mono,Roboto Mono,monospace",
-            color: "white",
-            borderColor: "#64ffda",
-            "&:hover": {
-              backgroundColor: "#64ffda",
-              color: "black",
-            },
-          }}
-        >
-          {item}
-        </Button>
+        <CustomButton name={item} marginR={"15px"} key={item} />
       ))}
     </AppBar>
   );

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -7,7 +7,7 @@ import MenuIcon from "@mui/icons-material/Menu";
 
 export default function Header() {
   const [isVisible, setIsVisible] = useState(true); // For header visibility
-  const [shadow, setShadow] = useState(false); // For header shadow state for not causing re-renders over and over again
+  const [shadow, setShadow] = useState(false); // For header shadow state
   const lastScroll = useRef(0); // For tracking last scroll position
   const headerItems = ["About Me", "Experience", "Skills", "Contact"];
   const headerButtons = ["Resume", "Vurdering", "Soft Skills"];
@@ -21,7 +21,12 @@ export default function Header() {
     setDrawerOpen((prev) => !prev); // Toggle drawer state
   };
 
+  // Detect when component is mounted
+  const [mounted, setMounted] = useState(false);
+
   useEffect(() => {
+    setMounted(true); // Once mounted, allow the component to render
+
     const handleScroll = () => {
       const currentScroll = window.scrollY;
       if (currentScroll > 0) {
@@ -45,6 +50,9 @@ export default function Header() {
     };
   }, []);
 
+  if (!mounted) return null;
+
+  // If it's mobile, render mobile layout with DrawerMenu
   return !isMobile ? (
     <AppBar
       sx={{

--- a/components/LandingPage.jsx
+++ b/components/LandingPage.jsx
@@ -1,4 +1,5 @@
-import { Box, Typography, Button } from "@mui/material";
+import { Box, Typography } from "@mui/material";
+import CustomButton from "./CustomButton";
 
 export default function LandingPage() {
   return (
@@ -54,23 +55,7 @@ export default function LandingPage() {
           would like to contact please hit the button!
         </Typography>
         {/*Contact Button*/}
-        <Button
-          variant="outlined"
-          sx={{
-            width: { xs: "40%", sm: "30%", md: "15%", lg: "10%" },
-            textTransform: "none",
-            fontSize: "13px",
-            fontFamily: "SF Mono,Fira Code,Fira Mono,Roboto Mono,monospace",
-            color: "white",
-            borderColor: "#64ffda",
-            "&:hover": {
-              backgroundColor: "#64ffda",
-              color: "black",
-            },
-          }}
-        >
-          Contact Me
-        </Button>
+        <CustomButton name={"Contact Me"} width={{ xs: "40%", sm: "30%", md: "15%", lg: "10%" }} />
       </Box>
     </>
   );

--- a/components/LandingPage.jsx
+++ b/components/LandingPage.jsx
@@ -55,7 +55,11 @@ export default function LandingPage() {
           would like to contact please hit the button!
         </Typography>
         {/*Contact Button*/}
-        <CustomButton name={"Contact Me"} width={{ xs: "40%", sm: "30%", md: "15%", lg: "10%" }} />
+        <CustomButton
+          name={"Contact Me"}
+          width={{ xs: "40%", sm: "30%", md: "15%", lg: "10%" }}
+          fontSize={"13px"}
+        />
       </Box>
     </>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@mui/icons-material": "^6.2.1",
         "@mui/material": "^6.2.1",
         "next": "15.1.0",
         "react": "^19.0.0",
@@ -722,6 +723,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.2.1.tgz",
+      "integrity": "sha512-bP0XtW+t5KFL+wjfQp2UctN/8CuWqF1qaxbYuCAsJhL+AzproM8gGOh2n8sNBcrjbVckzDNqaXqxdpn+OmoWug==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^6.2.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@mui/icons-material": "^6.2.1",
     "@mui/material": "^6.2.1",
     "next": "15.1.0",
     "react": "^19.0.0",


### PR DESCRIPTION

## Description

This pull request introduces a mobile-responsive navigation system by replacing the standard header with a hamburger menu on mobile devices. The normal header remains visible on desktop devices. When the hamburger menu is clicked on mobile, it opens to reveal the navigation options.

* What is this PR trying to accomplish?
    * Make the header navigation responsive by showing a hamburger menu on mobile and keeping the traditional header on desktop.
* What are the main changes made?
    * Added a media query to detect screen size and toggle between a standard header and a hamburger menu.
* Why is this change important?
    * This change improves the user experience on mobile devices by providing a compact navigation menu that doesn’t take up unnecessary screen space.


## Type of Change

Please mark the appropriate option(s):

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests
- [ ] Other (please specify)

## How to Test

1- Open the website on a desktop screen and verify that the normal header appears.
2- Open the website on a mobile screen (or resize the browser window to mobile dimensions).
3- Ensure that the hamburger menu appears in place of the normal header.
4- Click on the hamburger menu icon and verify that the menu opens with navigation options.


## Screenshots 

![header1](https://github.com/user-attachments/assets/c094e24c-fff4-4acc-aed7-7333ae04b5e6)
![header2](https://github.com/user-attachments/assets/d4755c80-8320-4b8b-989d-02b87cf74772)
![header3](https://github.com/user-attachments/assets/e1364c62-35d4-4837-8cd1-600987144d96)


